### PR TITLE
Loosen some cats/cats-effect constraints

### DIFF
--- a/.scalafmt.conf
+++ b/.scalafmt.conf
@@ -1,3 +1,4 @@
+version = "2.0.0-RC4"
 style = defaultWithAlign
 
 danglingParentheses        = true

--- a/src/main/scala/ch/chuv/lren/woken/dao/FeaturesRepository.scala
+++ b/src/main/scala/ch/chuv/lren/woken/dao/FeaturesRepository.scala
@@ -18,6 +18,7 @@
 package ch.chuv.lren.woken.dao
 
 import cats.data.{ NonEmptyList, Validated }
+import cats.Applicative
 import cats.effect.{ Effect, Resource }
 import cats.implicits._
 import ch.chuv.lren.woken.config.DatabaseConfiguration
@@ -132,9 +133,7 @@ trait FeaturesTableRepository[F[_]] extends Repository[F] {
     *
     * @param variables Full list of variables for the table as defined in the metadata
     */
-  def validateFields(variables: List[VariableMetaData])(
-      implicit effect: Effect[F]
-  ): F[Validated[NonEmptyList[(VariableMetaData, UserFeedback)], UserFeedbacks]] = {
+  def validateFields(variables: List[VariableMetaData])(implicit F: Applicative[F]): F[Validated[NonEmptyList[(VariableMetaData, UserFeedback)], UserFeedbacks]] = {
     val variableNames = variables.map(_.toId.code).toSet
     val headerNames   = columns.map(_.name).toSet
     val unknownHeaders =

--- a/src/main/scala/ch/chuv/lren/woken/dao/FeaturesRepositoryDAO.scala
+++ b/src/main/scala/ch/chuv/lren/woken/dao/FeaturesRepositoryDAO.scala
@@ -18,6 +18,8 @@
 package ch.chuv.lren.woken.dao
 
 import cats.Id
+import cats.Monad
+import cats.MonadError
 import doobie._
 import doobie.implicits._
 import spray.json._
@@ -42,10 +44,10 @@ import sup.HealthCheck
 
 import scala.language.higherKinds
 
-class FeaturesRepositoryDAO[F[_]: Effect] private (
+class FeaturesRepositoryDAO[F[_]] private (
     val xa: Transactor[F],
     override val database: DatabaseConfiguration
-) extends FeaturesRepository[F] {
+)(implicit F: MonadError[F, Throwable]) extends FeaturesRepository[F] {
 
   override def featuresTable(table: TableId): F[Option[FeaturesTableRepository[F]]] =
     database.tables
@@ -65,11 +67,11 @@ object FeaturesRepositoryDAO {
 
   implicit val han: LogHandler = logging.doobieLogHandler
 
-  def apply[F[_]: Effect](
+  def apply[F[_]](
       xa: Transactor[F],
       database: DatabaseConfiguration,
       wokenRepository: WokenRepository[F]
-  ): F[Validation[FeaturesRepositoryDAO[F]]] = {
+  )(implicit F: MonadError[F, Throwable]): F[Validation[FeaturesRepositoryDAO[F]]] = {
 
     case class Check(schema: String, table: String, column: String)
 
@@ -133,7 +135,7 @@ object FeaturesRepositoryDAO {
 
 }
 
-abstract class BaseFeaturesTableRepositoryDAO[F[_]: Effect] extends FeaturesTableRepository[F] {
+abstract class BaseFeaturesTableRepositoryDAO[F[_]: Monad] extends FeaturesTableRepository[F] {
   def xa: Transactor[F]
 
   implicit val han: LogHandler = logging.doobieLogHandler
@@ -242,11 +244,11 @@ abstract class BaseFeaturesTableRepositoryDAO[F[_]: Effect] extends FeaturesTabl
 
 }
 
-class FeaturesTableRepositoryDAO[F[_]: Effect] private[dao] (
+class FeaturesTableRepositoryDAO[F[_]] private[dao] (
     override val xa: Transactor[F],
     override val table: FeaturesTableDescription,
     override val columns: FeaturesTableRepository.Headers
-) extends BaseFeaturesTableRepositoryDAO[F] {
+)(implicit F: MonadError[F, Throwable]) extends BaseFeaturesTableRepositoryDAO[F] {
 
   @SuppressWarnings(Array("org.wartremover.warts.Any"))
   override def createExtendedFeaturesTable(
@@ -262,15 +264,15 @@ class FeaturesTableRepositoryDAO[F[_]: Effect] private[dao] (
                                        otherColumns,
                                        prefills,
                                        extendedTableNumber)
-      .map(_.map[FeaturesTableRepository[F]](t => t))
+      .map(_.widen[FeaturesTableRepository[F]])
 
   override def healthCheck: HealthCheck[F, Id] = validate(xa)
 }
 
 object FeaturesTableRepositoryDAO {
 
-  def apply[F[_]: Effect](xa: Transactor[F],
-                          table: FeaturesTableDescription): F[FeaturesTableRepositoryDAO[F]] = {
+  def apply[F[_]](xa: Transactor[F],
+                          table: FeaturesTableDescription)(implicit F: MonadError[F, Throwable]): F[FeaturesTableRepositoryDAO[F]] = {
     implicit val han: LogHandler = logging.doobieLogHandler
 
     HC.prepareStatement(s"SELECT * FROM ${table.quotedName} LIMIT 1")(prepareHeaders)
@@ -321,14 +323,14 @@ object FeaturesTableRepositoryDAO {
   }
 }
 
-class ExtendedFeaturesTableRepositoryDAO[F[_]: Effect] private (
+class ExtendedFeaturesTableRepositoryDAO[F[_]] private (
     val sourceTable: FeaturesTableRepositoryDAO[F],
     val view: FeaturesTableDescription,
     val viewColumns: List[TableColumn],
     val extTable: FeaturesTableDescription,
     val newFeatures: List[TableColumn],
     val rndColumn: TableColumn
-) extends BaseFeaturesTableRepositoryDAO[F] {
+)(implicit F: MonadError[F, Throwable]) extends BaseFeaturesTableRepositoryDAO[F] {
 
   override val xa: Transactor[F]               = sourceTable.xa
   override val table: FeaturesTableDescription = view
@@ -362,14 +364,14 @@ object ExtendedFeaturesTableRepositoryDAO {
 
   implicit val han: LogHandler = logging.doobieLogHandler
 
-  def apply[F[_]: Effect](
+  def apply[F[_]](
       sourceTable: FeaturesTableRepositoryDAO[F],
       filters: Option[FilterRule],
       newFeatures: List[TableColumn],
       otherColumns: List[TableColumn],
       prefills: List[PrefillExtendedFeaturesTable],
       extendedTableNumber: Int
-  ): Validation[Resource[F, ExtendedFeaturesTableRepositoryDAO[F]]] = {
+  )(implicit F: MonadError[F, Throwable]): Validation[Resource[F, ExtendedFeaturesTableRepositoryDAO[F]]] = {
 
     val xa       = sourceTable.xa
     val setSeed  = fr"SELECT setseed(" ++ frConst(sourceTable.table.seed) ++ fr");"
@@ -395,8 +397,7 @@ object ExtendedFeaturesTableRepositoryDAO {
                                           newColumns,
                                           extendedTableNumber)
           _ <- prefills
-            .map(_.prefillExtendedTableSql(sourceTable.table, extTable, rndColumn).run)
-            .sequence
+            .traverse(_.prefillExtendedTableSql(sourceTable.table, extTable, rndColumn).run)
           extViewCols <- createExtendedView(sourceTable.table,
                                             pk,
                                             sourceTable.columns,
@@ -415,15 +416,11 @@ object ExtendedFeaturesTableRepositoryDAO {
       }
 
     validatedDao.map { dao =>
-      Resource.make(dao)(_.close()).flatMap { f: ExtendedFeaturesTableRepositoryDAO[F] =>
-        {
-          Resource.make(Effect[F].delay(f))(_ => Effect[F].delay(()))
-        }
-      }
+      Resource.make(dao)(_.close())
     }
   }
 
-  private def createExtendedTable[F[_]: Effect](
+  private def createExtendedTable(
       table: FeaturesTableDescription,
       pk: TableColumn,
       filters: Option[FilterRule],
@@ -470,7 +467,7 @@ object ExtendedFeaturesTableRepositoryDAO {
 
   }
 
-  private def createExtendedView[F[_]: Effect](
+  private def createExtendedView(
       table: FeaturesTableDescription,
       pk: TableColumn,
       tableColumns: List[TableColumn],

--- a/src/main/scala/ch/chuv/lren/woken/dao/MetadataRepositoryDAO.scala
+++ b/src/main/scala/ch/chuv/lren/woken/dao/MetadataRepositoryDAO.scala
@@ -33,7 +33,7 @@ import variablesProtocol._
 import scala.collection.mutable
 import scala.language.higherKinds
 
-class VariablesMetaRepositoryDAO[F[_]: Effect](val xa: Transactor[F])
+class VariablesMetaRepositoryDAO[F[_]](val xa: Transactor[F])(implicit F: MonadError[F, Throwable])
     extends VariablesMetaRepository[F] {
 
   implicit val groupMetaDataMeta: Meta[GroupMetaData] = codecMeta[GroupMetaData]
@@ -91,7 +91,7 @@ class VariablesMetaRepositoryDAO[F[_]: Effect](val xa: Transactor[F])
   override def healthCheck: HealthCheck[F, Id] = validate(xa)
 }
 
-class TablesCatalogRepositoryDAO[F[_]: Effect](val xa: Transactor[F])
+class TablesCatalogRepositoryDAO[F[_]](val xa: Transactor[F])(implicit F: MonadError[F, Throwable])
     extends TablesCatalogRepository[F] {
 
   override def put(table: FeaturesTableDescription): F[FeaturesTableDescription] = ???
@@ -101,7 +101,7 @@ class TablesCatalogRepositoryDAO[F[_]: Effect](val xa: Transactor[F])
   override def healthCheck: HealthCheck[F, Id] = validate(xa)
 }
 
-case class MetadataRepositoryDAO[F[_]: Effect](xa: Transactor[F]) extends MetadataRepository[F] {
+case class MetadataRepositoryDAO[F[_]](xa: Transactor[F])(implicit F: MonadError[F, Throwable]) extends MetadataRepository[F] {
 
   override def variablesMeta: VariablesMetaRepository[F] = new VariablesMetaRepositoryDAO[F](xa)
 

--- a/src/main/scala/ch/chuv/lren/woken/dao/WokenRepositoryDAO.scala
+++ b/src/main/scala/ch/chuv/lren/woken/dao/WokenRepositoryDAO.scala
@@ -23,6 +23,7 @@ import java.util.{ Base64, UUID }
 import doobie._
 import doobie.implicits._
 import cats.Id
+import cats.MonadError
 import cats.data.Validated._
 import cats.effect.Effect
 import cats.implicits._
@@ -49,7 +50,7 @@ import sup.HealthCheck
 import scala.language.higherKinds
 import scala.util.Try
 
-case class WokenRepositoryDAO[F[_]: Effect](xa: Transactor[F]) extends WokenRepository[F] {
+case class WokenRepositoryDAO[F[_]](xa: Transactor[F])(implicit F: MonadError[F, Throwable]) extends WokenRepository[F] {
 
   private val genTableNum = sql"""
       SELECT nextval('gen_features_table_seq');
@@ -67,7 +68,7 @@ case class WokenRepositoryDAO[F[_]: Effect](xa: Transactor[F]) extends WokenRepo
 /**
   * Interpreter based on Doobie that provides the operations of the algebra
   */
-class JobResultRepositoryDAO[F[_]: Effect](val xa: Transactor[F])
+class JobResultRepositoryDAO[F[_]](val xa: Transactor[F])(implicit F: MonadError[F, Throwable])
     extends JobResultRepository[F]
     with LazyLogging {
 
@@ -213,7 +214,7 @@ class JobResultRepositoryDAO[F[_]: Effect](val xa: Transactor[F])
   override def healthCheck: HealthCheck[F, Id] = validate(xa)
 }
 
-class ResultsCacheRepositoryDAO[F[_]: Effect](val xa: Transactor[F])
+class ResultsCacheRepositoryDAO[F[_]](val xa: Transactor[F])(implicit F: MonadError[F, Throwable])
     extends ResultsCacheRepository[F] {
 
   private val systemUser = UserId("woken")

--- a/src/main/scala/ch/chuv/lren/woken/dao/package.scala
+++ b/src/main/scala/ch/chuv/lren/woken/dao/package.scala
@@ -18,6 +18,7 @@
 package ch.chuv.lren.woken
 
 import cats.Id
+import cats.MonadError
 import cats.effect.Effect
 import doobie.util.transactor.Transactor
 import sup.modules.doobie._
@@ -30,7 +31,7 @@ package object dao {
 
   import acyclic.pkg
 
-  def validate[F[_]: Effect](transactor: Transactor[F]): HealthCheck[F, Id] =
+  def validate[F[_]](transactor: Transactor[F])(implicit F: MonadError[F, Throwable]): HealthCheck[F, Id] =
     connectionCheck(transactor)(timeoutSeconds = Some(5)).through(mods.recoverToSick)
 
 }

--- a/src/main/scala/ch/chuv/lren/woken/service/FeaturesService.scala
+++ b/src/main/scala/ch/chuv/lren/woken/service/FeaturesService.scala
@@ -19,7 +19,7 @@ package ch.chuv.lren.woken.service
 
 import cats.Id
 import cats.data.{ NonEmptyList, Validated }
-import cats.effect.{ Effect, Resource }
+import cats.effect.{ Sync, Effect, Resource }
 import cats.syntax.validated._
 import ch.chuv.lren.woken.core.features.FeaturesQuery
 import ch.chuv.lren.woken.core.model.database.{ FeaturesTableDescription, TableColumn }
@@ -145,7 +145,7 @@ class FeaturesServiceImpl[F[_]: Effect](repository: FeaturesRepository[F])
   override def healthCheck: HealthCheck[F, Id] = repository.healthCheck
 }
 
-class FeaturesTableServiceImpl[F[_]: Effect](repository: FeaturesTableRepository[F])
+class FeaturesTableServiceImpl[F[_]: Sync](repository: FeaturesTableRepository[F])
     extends FeaturesTableService[F] {
 
   override def table: FeaturesTableDescription = repository.table
@@ -195,10 +195,10 @@ class FeaturesTableServiceImpl[F[_]: Effect](repository: FeaturesTableRepository
                                    extendedTableNumber)
       .map(
         _.flatMap { extendedTable =>
-          Resource.make(
-            Effect[F]
+          Resource.liftF(
+            Sync[F]
               .delay(new FeaturesTableServiceImpl(extendedTable): FeaturesTableService[F])
-          )(_ => Effect[F].delay(()))
+          )
         }
       )
 

--- a/src/main/scala/ch/chuv/lren/woken/service/QueryToJobService.scala
+++ b/src/main/scala/ch/chuv/lren/woken/service/QueryToJobService.scala
@@ -20,6 +20,7 @@ package ch.chuv.lren.woken.service
 import java.util.UUID
 
 import cats.data._
+import cats.Monad
 import cats.effect.{ Async, Effect }
 import cats.implicits._
 import ch.chuv.lren.woken.config.JobsConfiguration
@@ -77,7 +78,7 @@ object QueryToJobService extends LazyLogging {
   type PreparedQuery[Q <: Query] =
     JobId :: FeaturesTable :: List[VariableMetaData] :: Q :: UserFeedbacks :: HNil
 
-  def apply[F[_]: Effect](
+  def apply[F[_]: Monad](
       featuresService: FeaturesService[F],
       variablesMetaService: VariablesMetaRepository[F],
       jobsConfiguration: JobsConfiguration,
@@ -91,7 +92,7 @@ object QueryToJobService extends LazyLogging {
     )
 }
 
-class QueryToJobServiceImpl[F[_]: Effect](
+class QueryToJobServiceImpl[F[_]: Monad](
     featuresService: FeaturesService[F],
     variablesMetaService: VariablesMetaRepository[F],
     jobsConfiguration: JobsConfiguration,
@@ -355,6 +356,6 @@ class QueryToJobServiceImpl[F[_]: Effect](
   }
 
   private def toInvalidF[A](err: NonEmptyList[String]): F[Validation[A]] =
-    Async[F].delay(err.invalid[A])
+    Monad[F].pure(err.invalid[A])
 
 }

--- a/src/main/scala/ch/chuv/lren/woken/service/package.scala
+++ b/src/main/scala/ch/chuv/lren/woken/service/package.scala
@@ -29,8 +29,6 @@ package object service {
   /**
     * Return a resource encapsulating all services backed by a database
     */
-  def databaseResource[F[_]: ConcurrentEffect: ContextShift: Timer](config: WokenConfiguration)(
-      implicit cs: ContextShift[IO]
-  ): Resource[F, DatabaseServices[F]] = DatabaseServices.resource(config)
+  def databaseResource[F[_]: ConcurrentEffect: ContextShift: Timer](config: WokenConfiguration): Resource[F, DatabaseServices[F]] = DatabaseServices.resource(config)
 
 }


### PR DESCRIPTION
There's much more that could be done if there was no `runNow` that actually requires Effect, but that could be improved as well by wrapping the thing in `F` and sequencing it on a higher level. I only had enough time to spare to do this minor improvement, though...